### PR TITLE
Fix combobox unusable on mobile

### DIFF
--- a/packages/app/src/components/assets/CreateEdit/AssetCreateEditCustomFieldInput.tsx
+++ b/packages/app/src/components/assets/CreateEdit/AssetCreateEditCustomFieldInput.tsx
@@ -171,7 +171,7 @@ export const AssetCreateEditCustomFieldInput = ({
                 }}
                 max={customField.inputMax ?? undefined}
                 min={customField.inputMin ?? undefined}
-                placeholder="Select Tag"
+                placeholder="Select Tags"
               >
                 {tags?.map((tag) => (
                   <ComboBoxItem key={tag.id} value={tag.id}>

--- a/packages/app/src/components/common/ComboBox.tsx
+++ b/packages/app/src/components/common/ComboBox.tsx
@@ -29,7 +29,7 @@ import {
   Checkbox,
   useOutsideClick,
 } from "@chakra-ui/react";
-import { FiSearch } from "react-icons/fi";
+import { FiChevronDown, FiSearch } from "react-icons/fi";
 
 type ComboBoxProps<T> = {
   values?: T[];
@@ -135,7 +135,12 @@ export const ComboBox = <T extends number | string>({
   }, [isOpen]);
 
   return (
-    <FormControl isInvalid={!minimumReached}>
+    <FormControl
+      isInvalid={!minimumReached}
+      onFocus={focusInput}
+      onClick={focusInput}
+      ref={comboBoxRef}
+    >
       <Box position="relative">
         <Box
           borderWidth={1}
@@ -144,9 +149,6 @@ export const ComboBox = <T extends number | string>({
           overflow="hidden"
           borderColor={!minimumReached ? "red.500" : undefined}
           tabIndex={0}
-          onFocus={focusInput}
-          onClick={focusInput}
-          ref={comboBoxRef}
         >
           <Flex gap={2} alignItems={"flex-start"} flexWrap="wrap">
             {selectedItems.map((value) => (
@@ -162,9 +164,13 @@ export const ComboBox = <T extends number | string>({
             ))}
           </Flex>
           {selectedItems.length === 0 && (
-            <Text ml={1} color={"gray.500"}>
-              {placeholder}
-            </Text>
+            <Flex alignItems={"center"} justifyContent={"space-between"} px={1}>
+              <Text ml={1} color={"gray.500"}>
+                {placeholder}
+              </Text>
+
+              <Icon as={FiChevronDown} />
+            </Flex>
           )}
         </Box>
         <Box

--- a/packages/app/src/components/layout/DashboardLayout.tsx
+++ b/packages/app/src/components/layout/DashboardLayout.tsx
@@ -10,7 +10,10 @@ import { NavTopbar } from "../nav/NavTopbar";
 export const DashboardLayout = ({ children }: { children: ReactNode }) => (
   <Restricted>
     <OnboardingRedirect />
-    <Flex minH="100vh" flexDirection={{ base: "column", md: "row" }}>
+    <Flex
+      flexDirection={{ base: "column", md: "row" }}
+      minH={{ base: undefined, md: "100vh" }}
+    >
       <Show above="md">
         <Flex position="sticky" top="0" maxH="100vh" zIndex="1">
           <NavSidebar />


### PR DESCRIPTION
The outside click hook was triggered also when clicking inside the dropdown list, making the combobox unusable on mobile.