### PR TITLE
#62 Add advanced asset table filtering

### DIFF
--- a/packages/app/schemas/import-0.3.0.schema.json
+++ b/packages/app/schemas/import-0.3.0.schema.json
@@ -1,0 +1,400 @@
+{
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 250
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 10
+    },
+    "description": {
+      "type": "string",
+      "minLength": 0,
+      "maxLength": 1000
+    },
+    "author": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 250
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 250
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "$ref": "#/properties/tags/items"
+            }
+          }
+        },
+        "required": [
+          "name",
+          "children"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "assetTypes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 250
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "NUMBER"
+                    },
+                    "inputMin": {
+                      "type": "number"
+                    },
+                    "inputMax": {
+                      "type": "number"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "inputRequired": {
+                      "type": "boolean"
+                    },
+                    "showInTable": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "name",
+                    "inputRequired",
+                    "showInTable"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "STRING"
+                    },
+                    "inputMin": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/inputMin"
+                    },
+                    "inputMax": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/inputMax"
+                    },
+                    "id": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/id"
+                    },
+                    "name": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/name"
+                    },
+                    "inputRequired": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/inputRequired"
+                    },
+                    "showInTable": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/showInTable"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "name",
+                    "inputRequired",
+                    "showInTable"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "BOOLEAN"
+                    },
+                    "id": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/id"
+                    },
+                    "name": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/name"
+                    },
+                    "inputRequired": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/inputRequired"
+                    },
+                    "showInTable": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/showInTable"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "name",
+                    "inputRequired",
+                    "showInTable"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "DATE"
+                    },
+                    "id": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/id"
+                    },
+                    "name": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/name"
+                    },
+                    "inputRequired": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/inputRequired"
+                    },
+                    "showInTable": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/showInTable"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "name",
+                    "inputRequired",
+                    "showInTable"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "TIME"
+                    },
+                    "id": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/id"
+                    },
+                    "name": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/name"
+                    },
+                    "inputRequired": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/inputRequired"
+                    },
+                    "showInTable": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/showInTable"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "name",
+                    "inputRequired",
+                    "showInTable"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "DATETIME"
+                    },
+                    "id": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/id"
+                    },
+                    "name": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/name"
+                    },
+                    "inputRequired": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/inputRequired"
+                    },
+                    "showInTable": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/showInTable"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "name",
+                    "inputRequired",
+                    "showInTable"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "CURRENCY"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "inputMin": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/inputMin"
+                    },
+                    "inputMax": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/inputMax"
+                    },
+                    "id": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/id"
+                    },
+                    "name": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/name"
+                    },
+                    "inputRequired": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/inputRequired"
+                    },
+                    "showInTable": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/showInTable"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "name",
+                    "inputRequired",
+                    "showInTable"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "TAG"
+                    },
+                    "parentTagId": {
+                      "type": "string"
+                    },
+                    "inputMin": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/inputMin"
+                    },
+                    "inputMax": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/inputMax"
+                    },
+                    "id": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/id"
+                    },
+                    "name": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/name"
+                    },
+                    "inputRequired": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/inputRequired"
+                    },
+                    "showInTable": {
+                      "$ref": "#/properties/assetTypes/items/properties/fields/items/anyOf/0/properties/showInTable"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "parentTagId",
+                    "name",
+                    "inputRequired",
+                    "showInTable"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "$ref": "#/properties/assetTypes/items"
+            }
+          }
+        },
+        "required": [
+          "name",
+          "fields"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "assets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "assetTypeId": {
+            "type": "string"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "fieldId": {
+                  "type": "string"
+                },
+                "value": {
+                  "anyOf": [
+                    {
+                      "type": [
+                        "string",
+                        "number",
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "fieldId",
+                "value"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "assetTypeId",
+          "values"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "name",
+    "version"
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/packages/app/src/components/assets/List/AssetTableContext.tsx
+++ b/packages/app/src/components/assets/List/AssetTableContext.tsx
@@ -1,0 +1,68 @@
+import { createContext, useContext, useState } from "react";
+import { type FacetFilter } from "./filter/facetFilter";
+import { type AssetTypeField } from "~/server/lib/asset-types/assetType";
+import { useFilterBuilder } from "./filter/useFilterBuilder.hook";
+
+type AssetTableContextValue = ReturnType<typeof useAssetTableContextValue>;
+
+const AssetTableContext = createContext<AssetTableContextValue | null>(null);
+
+export const AssetTableProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const contextValue = useAssetTableContextValue();
+
+  return (
+    <AssetTableContext.Provider value={contextValue}>
+      {children}
+    </AssetTableContext.Provider>
+  );
+};
+
+export const useAssetTable = () => {
+  const contextValue = useContext(AssetTableContext);
+
+  if (contextValue === null) {
+    throw new Error("useAssetTable must be used within AssetTableProvider");
+  }
+
+  return contextValue;
+};
+
+const useAssetTableContextValue = () => {
+  const [filters, setFilters] = useState<FacetFilter[]>([]);
+  const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
+  const filterExpression = useFilterBuilder(filters, selectedTypes);
+
+  return {
+    filters,
+    filterExpression,
+    clearFilters: () => setFilters([]),
+    updateFilter: (filter: FacetFilter) => {
+      setFilters((prev) => {
+        const newState = prev.filter(
+          ({ field }) => field.id !== filter.field.id
+        );
+        if (filter.conditions.length > 0) {
+          newState.push(filter);
+        }
+        return newState;
+      });
+    },
+    selectedTypes,
+    setSelectedTypes,
+  };
+};
+
+export const useAssetTableFilter = (field: AssetTypeField) => {
+  const { filters } = useAssetTable();
+
+  return (
+    filters.find((filter) => filter.field.id === field.id) ?? {
+      field,
+      conditions: [],
+    }
+  );
+};

--- a/packages/app/src/components/assets/List/filter/CustomFieldFilter.tsx
+++ b/packages/app/src/components/assets/List/filter/CustomFieldFilter.tsx
@@ -1,0 +1,150 @@
+import { type CategoriesDistribution } from "meilisearch";
+import {
+  Button,
+  Checkbox,
+  Collapse,
+  Divider,
+  Flex,
+  Tag,
+  useDisclosure,
+} from "@chakra-ui/react";
+import { FieldType } from "@prisma/client";
+import { type ReactElement } from "react";
+import { type FilterKeyValue, type FacetFilter } from "./facetFilter";
+import { FiChevronDown, FiChevronUp } from "react-icons/fi";
+import { useAssetTable, useAssetTableFilter } from "../AssetTableContext";
+import { type AssetTypeField } from "~/server/lib/asset-types/assetType";
+
+type CustomFieldFilterProps = {
+  filter: FacetFilter;
+  distribution: CategoriesDistribution;
+  onChange: (filter: FacetFilter) => void;
+};
+
+const buildFacetFilter =
+  (
+    filter: FacetFilter,
+    onChange: (filter: FacetFilter) => void,
+    value: string
+  ) =>
+  (event: React.ChangeEvent<HTMLInputElement>) => {
+    const checked = event.target.checked;
+    const conditions: FilterKeyValue[] = filter.conditions.filter(
+      ({ value: v }) => v !== value
+    );
+
+    if (checked) {
+      conditions.push({ key: filter.field.slug, value });
+    }
+
+    onChange({
+      ...filter,
+      conditions,
+    });
+  };
+
+const isChecked = (filter: FacetFilter, value: string) =>
+  filter.conditions.some(({ value: v }) => v === value);
+
+const CheckboxFilter = ({
+  filter,
+  distribution,
+  onChange,
+}: CustomFieldFilterProps) => {
+  const truncateLimit = 5;
+  const isTruncated = Object.keys(distribution ?? {}).length > truncateLimit;
+  const truncatedDistribution = isTruncated
+    ? Object.fromEntries(
+        Object.entries(distribution ?? {}).slice(0, truncateLimit)
+      )
+    : distribution;
+  const additionalDistribution = isTruncated
+    ? Object.entries(distribution ?? {}).slice(truncateLimit)
+    : [];
+
+  const { isOpen, getButtonProps } = useDisclosure();
+
+  return (
+    <Flex direction="column" gap={2}>
+      {Object.entries(truncatedDistribution ?? {}).map(([value, count]) => (
+        <Checkbox
+          key={`${filter.field.id}-${value}`}
+          isChecked={isChecked(filter, value)}
+          onChange={buildFacetFilter(filter, onChange, value)}
+        >
+          {value} <Tag rounded="full">{count}</Tag>
+        </Checkbox>
+      ))}
+      <Collapse in={isOpen} animateOpacity>
+        <Flex direction="column" gap={2}>
+          {additionalDistribution.map(([value, count]) => (
+            <Checkbox
+              key={`${filter.field.id}-${value}`}
+              isChecked={isChecked(filter, value)}
+              onChange={buildFacetFilter(filter, onChange, value)}
+            >
+              {value} <Tag rounded="full">{count}</Tag>
+            </Checkbox>
+          ))}
+        </Flex>
+      </Collapse>
+      {isTruncated && (
+        <>
+          <Divider />
+          <Button
+            size="xs"
+            {...getButtonProps()}
+            variant={"ghost"}
+            leftIcon={isOpen ? <FiChevronUp /> : <FiChevronDown />}
+          >
+            {isOpen
+              ? "Show less"
+              : `Show ${additionalDistribution.length} more`}
+          </Button>
+        </>
+      )}
+    </Flex>
+  );
+};
+
+const BooleanFilter = ({
+  filter,
+  distribution,
+  onChange,
+}: CustomFieldFilterProps) => (
+  <Flex direction="column" gap={2}>
+    {Object.entries(distribution ?? {}).map(([value, count]) => (
+      <Checkbox
+        key={`${filter.field.id}-${value}`}
+        isChecked={isChecked(filter, value)}
+        onChange={buildFacetFilter(filter, onChange, value)}
+      >
+        {value === "true" ? "Yes" : "No"} <Tag rounded="full">{count}</Tag>
+      </Checkbox>
+    ))}
+  </Flex>
+);
+
+const filterType: Partial<
+  Record<FieldType, (props: CustomFieldFilterProps) => ReactElement>
+> = {
+  [FieldType.TAG]: CheckboxFilter,
+  [FieldType.STRING]: CheckboxFilter,
+  [FieldType.BOOLEAN]: BooleanFilter,
+};
+
+export const CustomFieldFilter = ({
+  field,
+  distribution,
+}: {
+  field: AssetTypeField;
+  distribution: CategoriesDistribution;
+}) => {
+  const { updateFilter } = useAssetTable();
+  const filter = useAssetTableFilter(field);
+  return filterType[filter.field.fieldType]?.({
+    filter,
+    distribution,
+    onChange: updateFilter,
+  });
+};

--- a/packages/app/src/components/assets/List/filter/FilterOptions.tsx
+++ b/packages/app/src/components/assets/List/filter/FilterOptions.tsx
@@ -1,0 +1,120 @@
+import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Box,
+  Heading,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Stack,
+  Tag,
+  useBreakpointValue,
+} from "@chakra-ui/react";
+import { ComboBox, ComboBoxItem } from "~/components/common/ComboBox";
+import { type AssetSearchResponse } from "~/server/lib/assets/assetSearchRequest";
+import { type AssetType } from "~/server/lib/asset-types/assetType";
+import { CustomFieldFilter } from "./CustomFieldFilter";
+import { motion, AnimatePresence } from "framer-motion";
+import { useFacetedFields } from "../useFacetedFields";
+
+type FilterOptionsProps = {
+  assetsResponse?: AssetSearchResponse;
+  assetTypes: AssetType[];
+  isOpen: boolean;
+  onClose: VoidFunction;
+};
+
+export const FilterOptions = ({
+  isOpen,
+  onClose,
+  assetsResponse,
+  assetTypes,
+}: FilterOptionsProps) => {
+  const type = useBreakpointValue({ base: "modal", xl: "sidebar" });
+  const { facetedFields, selectedTypes, setSelectedTypes } = useFacetedFields({
+    assetsResponse,
+    assetTypes,
+  });
+
+  const filterStack = (
+    <>
+      <Stack gap={2} minW={"250px"}>
+        <ComboBox
+          placeholder="Asset type"
+          values={selectedTypes}
+          onChange={setSelectedTypes}
+          variant="grouped"
+          itemName={{ singular: "Type", plural: "Types" }}
+        >
+          {assetTypes.map((assetType) => (
+            <ComboBoxItem key={assetType.id} value={assetType.name}>
+              {assetType.name}{" "}
+              <Tag rounded="full">
+                {assetsResponse?.facetDistribution?.assetTypeName?.[
+                  assetType.name
+                ] ?? 0}
+              </Tag>
+            </ComboBoxItem>
+          ))}
+        </ComboBox>
+        <Accordion defaultIndex={[0]} allowMultiple>
+          {facetedFields.map((field) => (
+            <AccordionItem key={field.field.id}>
+              <AccordionButton>
+                <Box flex="1" textAlign="left">
+                  {field.field.name}
+                </Box>
+                <AccordionIcon />
+              </AccordionButton>
+              <AccordionPanel>
+                <CustomFieldFilter
+                  field={field.field}
+                  distribution={field.distribution ?? {}}
+                />
+              </AccordionPanel>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      </Stack>
+    </>
+  );
+
+  const filterSidebar = (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0, x: 50 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: 50 }}
+          transition={{ duration: 0.2, ease: "backOut" }}
+        >
+          <Box borderWidth={1} rounded={"md"} p={4}>
+            <Heading size="sm" mb={4}>
+              Filters
+            </Heading>
+            {filterStack}
+          </Box>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+
+  const filterModal = (
+    <Modal isOpen={isOpen} onClose={onClose} onOverlayClick={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Filters</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>{filterStack}</ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+
+  return type === "modal" ? filterModal : filterSidebar;
+};

--- a/packages/app/src/components/assets/List/filter/facetFilter.ts
+++ b/packages/app/src/components/assets/List/filter/facetFilter.ts
@@ -1,0 +1,11 @@
+import { type AssetTypeField } from "~/server/lib/asset-types/assetType";
+
+export type FilterKeyValue = {
+  key: string;
+  value: string;
+};
+
+export type FacetFilter = {
+  field: AssetTypeField;
+  conditions: FilterKeyValue[];
+};

--- a/packages/app/src/components/assets/List/filter/useFilterBuilder.hook.ts
+++ b/packages/app/src/components/assets/List/filter/useFilterBuilder.hook.ts
@@ -1,0 +1,23 @@
+import { useMemo } from "react";
+import { type FacetFilter } from "./facetFilter";
+
+export const useFilterBuilder = (
+  filter: FacetFilter[],
+  assetTypes: string[]
+) => {
+  const expression = useMemo(() => {
+    const parts = filter.map((facetFilter) =>
+      facetFilter.conditions
+        .map((condition) => `"${condition.key}" = "${condition.value}"`)
+        .join(" OR ")
+    );
+    if (assetTypes.length > 0) {
+      parts.push(
+        assetTypes.map((type) => `"assetTypeName" = "${type}"`).join(" OR ")
+      );
+    }
+
+    return parts.join(" AND ");
+  }, [filter, assetTypes]);
+  return expression;
+};

--- a/packages/app/src/components/assets/List/useFacetedFields.ts
+++ b/packages/app/src/components/assets/List/useFacetedFields.ts
@@ -1,0 +1,58 @@
+import { usePrevious } from "@chakra-ui/react";
+import { FieldType } from "@prisma/client";
+import { useEffect, useMemo } from "react";
+import { type AssetType } from "~/server/lib/asset-types/assetType";
+import { type AssetSearchResponse } from "~/server/lib/assets/assetSearchRequest";
+import { useAssetTable } from "./AssetTableContext";
+
+const supportedFieldTypes: FieldType[] = [
+  FieldType.STRING,
+  FieldType.TAG,
+  FieldType.BOOLEAN,
+];
+
+export const useFacetedFields = ({
+  assetsResponse,
+  assetTypes,
+}: {
+  assetsResponse?: AssetSearchResponse;
+  assetTypes: AssetType[];
+}) => {
+  const { selectedTypes, setSelectedTypes } = useAssetTable();
+  const assetTypeNames = Object.keys(
+    assetsResponse?.facetDistribution?.assetTypeName ?? {}
+  );
+  const previousAssetTypeNames = usePrevious(assetTypeNames);
+  const facetedFields = useMemo(
+    () =>
+      assetTypes
+        .filter(
+          (type) =>
+            selectedTypes.includes(type.name) || selectedTypes.length === 0
+        )
+        .flatMap((type) => type.fields)
+        .filter((field) => supportedFieldTypes.includes(field.fieldType))
+        .map((field) => ({
+          field,
+          distribution: assetsResponse?.facetDistribution?.[field.slug],
+          stats: assetsResponse?.facetStats?.[field.slug],
+        }))
+        .filter(
+          ({ distribution }) =>
+            !!distribution && Object.keys(distribution).length > 0
+        ),
+    [assetTypes, selectedTypes, assetsResponse]
+  );
+
+  useEffect(() => {
+    if (previousAssetTypeNames?.length === 0 && assetTypeNames?.length > 0) {
+      setSelectedTypes(assetTypeNames);
+    }
+  }, [assetTypeNames, previousAssetTypeNames, setSelectedTypes]);
+
+  return {
+    facetedFields,
+    selectedTypes,
+    setSelectedTypes,
+  };
+};

--- a/packages/app/src/components/auth/CredentialsRegisterForm.tsx
+++ b/packages/app/src/components/auth/CredentialsRegisterForm.tsx
@@ -50,7 +50,6 @@ export const CredentialsRegisterForm = () => {
     } catch (e) {
       if (e instanceof Error) {
         setRegisterError.on();
-        console.log(e.message);
         setError("email", { message: "Invalid credentials" });
         setError("password", { message: "Invalid credentials" });
       }

--- a/packages/app/src/components/common/ComboBox.tsx
+++ b/packages/app/src/components/common/ComboBox.tsx
@@ -70,7 +70,7 @@ export const ComboBox = <T extends number | string>({
     removeSelectedItem,
     selectedItems,
   } = useMultipleSelection<T>({
-    initialSelectedItems: values,
+    selectedItems: values,
     onSelectedItemsChange: ({ selectedItems }) => {
       if (selectedItems) {
         onChange?.(selectedItems);
@@ -146,6 +146,7 @@ export const ComboBox = <T extends number | string>({
       onFocus={focusInput}
       onClick={focusInput}
       ref={comboBoxRef}
+      w={"auto"}
     >
       <Box position="relative">
         <Box
@@ -155,7 +156,6 @@ export const ComboBox = <T extends number | string>({
           overflow="hidden"
           borderColor={!minimumReached ? "red.500" : undefined}
           tabIndex={0}
-          minW={"1"}
         >
           {variant === "inline" && (
             <>
@@ -199,7 +199,7 @@ export const ComboBox = <T extends number | string>({
               justifyContent={"space-between"}
               px={1}
               gap={2}
-              height={"23px"}
+              height={"22px"}
             >
               <Flex gap={2}>
                 <Tag rounded={"full"}>
@@ -226,6 +226,7 @@ export const ComboBox = <T extends number | string>({
           width="full"
           zIndex="dropdown"
           boxShadow={"lg"}
+          w={"max-content"}
         >
           <InputGroup hidden={!isSearchable} mb={2}>
             <InputLeftElement pointerEvents="none">

--- a/packages/app/src/components/common/DataTable/DataTable.tsx
+++ b/packages/app/src/components/common/DataTable/DataTable.tsx
@@ -18,6 +18,9 @@ import {
   Input,
   TableContainer,
   Progress,
+  HStack,
+  Spacer,
+  VStack,
 } from "@chakra-ui/react";
 import {
   useReactTable,
@@ -39,6 +42,7 @@ export type DataTableProps<Data extends object> = {
   data: Data[];
   columns: ColumnDef<Data, any>[];
   emptyList?: EmptyListIconProps | null;
+  filterActions?: React.ReactNode;
   tableActions?: React.ReactNode;
   isLoading?: boolean;
 } & TableProps;
@@ -50,6 +54,7 @@ export function DataTable<Data extends object>({
     icon: FiFile,
     label: "No data found",
   },
+  filterActions,
   tableActions,
   isLoading,
   ...tableProps
@@ -81,35 +86,35 @@ export function DataTable<Data extends object>({
   });
 
   return (
-    <>
-      <Flex justify="space-between">
-        <Flex gap={2}>
-          <InputGroup>
-            <InputLeftElement>
-              <Icon as={FiSearch} color="gray.500" />
-            </InputLeftElement>
-            <Input
-              placeholder="Search"
-              value={searchValue}
-              onChange={(e) => setSearchValue(e.currentTarget.value)}
-            />
-          </InputGroup>
-          <ComboBox
-            values={visibleColumns}
-            onChange={setVisibleColumns}
-            variant="grouped"
-            itemName={{ singular: "Column", plural: "Columns" }}
-            isSearchable={filterableColumns.length >= 5}
-          >
-            {filterableColumns.map((column) => (
-              <ComboBoxItem key={column.id} value={column.id}>
-                {(column.meta as any)?.filterLabel ?? column.header?.toString()}
-              </ComboBoxItem>
-            ))}
-          </ComboBox>
-        </Flex>
-        {tableActions}
-      </Flex>
+    <VStack align={"stretch"} gap={6}>
+      <HStack>
+        <InputGroup maxW={"180px"}>
+          <InputLeftElement>
+            <Icon as={FiSearch} color="gray.500" />
+          </InputLeftElement>
+          <Input
+            placeholder="Search"
+            value={searchValue}
+            onChange={(e) => setSearchValue(e.currentTarget.value)}
+          />
+        </InputGroup>
+        <ComboBox
+          values={visibleColumns}
+          onChange={setVisibleColumns}
+          variant="grouped"
+          itemName={{ singular: "Column", plural: "Columns" }}
+          isSearchable={filterableColumns.length >= 5}
+        >
+          {filterableColumns.map((column) => (
+            <ComboBoxItem key={column.id} value={column.id}>
+              {(column.meta as any)?.filterLabel ?? column.header?.toString()}
+            </ComboBoxItem>
+          ))}
+        </ComboBox>
+        {filterActions}
+        <Spacer />
+        <Flex justifyContent={"flex-end"}>{tableActions}</Flex>
+      </HStack>
       <TableContainer>
         <Table {...tableProps}>
           <Thead>
@@ -195,7 +200,7 @@ export function DataTable<Data extends object>({
           </Tbody>
         </Table>
       </TableContainer>
-      <Flex justifyContent={"end"}>
+      <Flex justifyContent={"end"} mt={2}>
         <Pagination
           pageIndex={pagination.pageIndex}
           pageSize={pagination.pageSize}
@@ -208,6 +213,6 @@ export function DataTable<Data extends object>({
           setPageSize={table.setPageSize}
         />
       </Flex>
-    </>
+    </VStack>
   );
 }

--- a/packages/app/src/components/settings/LabelTemplateSettings/LabelTemplateCreateEditForm.tsx
+++ b/packages/app/src/components/settings/LabelTemplateSettings/LabelTemplateCreateEditForm.tsx
@@ -29,7 +29,6 @@ import { type LabelTemplateCreateEditRequest } from "@/server/lib/label-template
 import { api } from "@/utils/api";
 import { LabelTemplatePrintPreview } from "./LabelTemplatePrintPreview";
 import { LabelComponents } from "@prisma/client";
-import { useEffect } from "react";
 import { useTeam } from "@/lib/SelectedTeamProvider";
 
 export const LabelTemplateCreateEditForm = ({
@@ -122,10 +121,6 @@ export const LabelTemplateCreateEditForm = ({
     });
     refetch?.();
   };
-
-  useEffect(() => {
-    console.log(errors);
-  }, [errors]);
 
   return (
     <Stack gap={2}>

--- a/packages/app/src/pages/assets/index.tsx
+++ b/packages/app/src/pages/assets/index.tsx
@@ -1,9 +1,12 @@
 import { AssetTable } from "@/components/assets/List/AssetTable";
+import { AssetTableProvider } from "~/components/assets/List/AssetTableContext";
 
 export default function Assets() {
   return (
     <>
-      <AssetTable />
+      <AssetTableProvider>
+        <AssetTable />
+      </AssetTableProvider>
     </>
   );
 }

--- a/packages/app/src/server/api/routers/asset.ts
+++ b/packages/app/src/server/api/routers/asset.ts
@@ -3,6 +3,7 @@ import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
 import { assetCreateEditRequest } from "@/server/lib/assets/assetCreateEditRequest";
 import { assetDeleteRequest } from "@/server/lib/assets/assetDeleteRequest";
 import { assetListRequest } from "@/server/lib/assets/assetListRequest";
+import { assetSearchRequest } from "~/server/lib/assets/assetSearchRequest";
 
 export const assetRouter = createTRPCRouter({
   create: protectedProcedure
@@ -33,6 +34,14 @@ export const assetRouter = createTRPCRouter({
     .input(assetListRequest)
     .query(async ({ ctx, input }) => {
       return ctx.applicationContext.assetService.getAssets(
+        ctx.session.user.id,
+        input
+      );
+    }),
+  search: protectedProcedure
+    .input(assetSearchRequest)
+    .query(async ({ ctx, input }) => {
+      return ctx.applicationContext.assetService.searchAssets(
         ctx.session.user.id,
         input
       );

--- a/packages/app/src/server/lib/asset-types/assetType.ts
+++ b/packages/app/src/server/lib/asset-types/assetType.ts
@@ -7,3 +7,4 @@ export type AssetType = AssetTypeRelation & {
   children: AssetType[];
   fields: CustomFieldRelation[];
 };
+export type AssetTypeField = AssetType["fields"][0];

--- a/packages/app/src/server/lib/assets/assetSearchRequest.ts
+++ b/packages/app/src/server/lib/assets/assetSearchRequest.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { type AssetWithFields } from "./asset";
+import { type FacetDistribution, type FacetStats } from "meilisearch";
+
+export const assetSearchRequest = z.object({
+  teamId: z.string(),
+  limit: z.number().optional(),
+  offset: z.number().optional(),
+  filter: z.string().optional(),
+});
+
+export type AssetSearchRequest = z.infer<typeof assetSearchRequest>;
+export type AssetSearchResponse = {
+  assets: AssetWithFields[];
+  facetDistribution?: FacetDistribution;
+  facetStats?: FacetStats;
+};

--- a/packages/app/src/server/lib/import/importJob.ts
+++ b/packages/app/src/server/lib/import/importJob.ts
@@ -2,20 +2,27 @@ import { type Logger } from "winston";
 import { type AssetTypeService } from "../asset-types/assetTypeService";
 import { type TagService } from "../tags/tagService";
 import {
+  type ImportField,
+  type ImportAsset,
   type ImportAssetType,
   type ImportSchema,
   type ImportTag,
 } from "./importSchema";
 import { FieldType } from "@prisma/client";
 import { mapAssetTypeImport } from "./assetTypeImportMapper";
+import { type AssetService } from "../assets/assetService";
+import { type AssetCreateEditCustomFieldValue } from "../assets/assetCreateEditRequest";
 
 export class ImportJob {
   private tagIdMap = new Map<string, string>();
+  private assetTypeIdMap = new Map<string, string>();
+  private fieldIdMap = new Map<string, string>();
 
   constructor(
     private readonly logger: Logger,
     private readonly assetTypeService: AssetTypeService,
     private readonly tagService: TagService,
+    private readonly assetService: AssetService,
     private readonly userId: string,
     private readonly teamId: string
   ) {}
@@ -30,6 +37,14 @@ export class ImportJob {
         await this.createAssetType(assetType, null);
       }
     }
+
+    if (importData.assets) {
+      await this.createAssets(
+        importData.assets,
+        importData.assetTypes?.flatMap((at) => at.fields) ?? []
+      );
+    }
+
     this.logger.info("Imported data");
   }
 
@@ -78,6 +93,23 @@ export class ImportJob {
       { id: null, name: assetType.name, fields, teamId: this.teamId, parentId }
     );
 
+    const createdFields = createdAssetType.fields;
+    for (let i = 0; i < assetTypeCreateRequest.fields.length; i++) {
+      const importId = assetType.fields[i]?.id;
+      if (!importId) {
+        continue;
+      }
+      const fieldId = createdFields[i]?.id;
+      if (!fieldId) {
+        continue;
+      }
+      this.fieldIdMap.set(importId, fieldId);
+    }
+
+    if (assetType.id) {
+      this.assetTypeIdMap.set(assetType.id, createdAssetType.assetType.id);
+    }
+
     if (assetType.children && assetType.children.length > 0) {
       for (const childAssetType of assetType.children) {
         await this.createAssetType(
@@ -85,6 +117,50 @@ export class ImportJob {
           createdAssetType.assetType.id
         );
       }
+    }
+  }
+
+  private async createAssets(assets: ImportAsset[], fields: ImportField[]) {
+    for (const asset of assets) {
+      const assetTypeId = this.assetTypeIdMap.get(asset.assetTypeId);
+      if (!assetTypeId) {
+        throw new Error(`Asset type ID ${asset.assetTypeId} not found.`);
+      }
+      await this.assetService.createAsset(this.userId, {
+        teamId: this.teamId,
+        assetTypeId,
+        customFieldValues: asset.values.map((value) => {
+          const field = fields.find((field) => field.id === value.fieldId);
+          if (!field) {
+            throw new Error(`Field ID ${value.fieldId} not found in fields.`);
+          }
+          const fieldId = this.fieldIdMap.get(value.fieldId);
+          if (!fieldId) {
+            throw new Error(`Field ID ${value.fieldId} not found.`);
+          }
+          const arrayValue = Array.isArray(value.value) ? value.value : [];
+          const singleValue = Array.isArray(value.value) ? null : value.value;
+          return {
+            fieldId,
+            booleanValue: typeof singleValue === "boolean" ? singleValue : null,
+            dateTimeValue:
+              typeof singleValue === "string" && field.type === FieldType.DATE
+                ? new Date(singleValue)
+                : null,
+            numberValue:
+              typeof singleValue === "number" && field.type === FieldType.NUMBER
+                ? singleValue
+                : null,
+            decimalValue: null, // fine for now
+            stringValue: typeof singleValue === "string" ? singleValue : null,
+            tagsValue: Array.isArray(value.value)
+              ? arrayValue
+                  .map((id) => this.tagIdMap.get(id))
+                  .filter((id): id is string => !!id)
+              : null,
+          } satisfies AssetCreateEditCustomFieldValue;
+        }),
+      });
     }
   }
 }

--- a/packages/app/src/server/lib/import/importSchema.ts
+++ b/packages/app/src/server/lib/import/importSchema.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { FieldType } from "@prisma/client";
 
 const baseCustomFieldCreateEditRequest = {
+  id: z.string().optional(),
   name: z.string(),
   inputRequired: z.boolean(),
   showInTable: z.boolean(),
@@ -66,13 +67,14 @@ const tagBase = z.object({
   name: z.string().min(1).max(250),
 });
 type Tag = z.infer<typeof tagBase> & {
-  children: Tag[];
+  children?: Tag[];
 };
 const tag: z.ZodType<Tag> = tagBase.extend({
-  children: z.lazy(() => z.array(tag)),
+  children: z.lazy(() => z.array(tag)).optional(),
 });
 
 const assetTypeBase = z.object({
+  id: z.string().optional(),
   name: z.string().min(1).max(250),
   fields: z.array(field),
 });
@@ -83,6 +85,17 @@ const assetType: z.ZodType<AssetType> = assetTypeBase.extend({
   children: z.lazy(() => z.array(assetType).optional()),
 });
 
+const value = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+
+const fieldValue = z.object({
+  fieldId: z.string(),
+  value: value.or(z.array(z.string())),
+});
+const asset = z.object({
+  assetTypeId: z.string(),
+  values: z.array(fieldValue),
+});
+
 export const importSchema = z.object({
   $schema: z.string().optional(),
   name: z.string().min(1).max(250),
@@ -91,11 +104,13 @@ export const importSchema = z.object({
   author: z.string().min(1).max(250).optional(),
   tags: z.array(tag).optional(),
   assetTypes: z.array(assetType).optional(),
+  assets: z.array(asset).optional(),
 });
 
-export const importSchemaVersion = "0.2.0";
+export const importSchemaVersion = "0.3.0";
 
 export type ImportSchema = z.infer<typeof importSchema>;
 export type ImportAssetType = z.infer<typeof assetType>;
 export type ImportField = z.infer<typeof field>;
 export type ImportTag = z.infer<typeof tag>;
+export type ImportAsset = z.infer<typeof asset>;

--- a/packages/app/src/server/lib/import/importService.ts
+++ b/packages/app/src/server/lib/import/importService.ts
@@ -5,12 +5,14 @@ import { importSchema, type ImportSchema } from "./importSchema";
 import { type AssetTypeService } from "../asset-types/assetTypeService";
 import { type TagService } from "../tags/tagService";
 import { ImportJob } from "./importJob";
+import { type AssetService } from "../assets/assetService";
 
 export class ImportService {
   constructor(
     private readonly logger: Logger,
     private readonly teamService: TeamService,
     private readonly assetTypeService: AssetTypeService,
+    private readonly assetService: AssetService,
     private readonly tagService: TagService
   ) {}
 
@@ -32,6 +34,7 @@ export class ImportService {
       this.logger.child({ name: "ImportJob" }),
       this.assetTypeService,
       this.tagService,
+      this.assetService,
       userId,
       importRequest.teamId
     ).execute(importData);

--- a/packages/app/src/server/lib/search/abstractSearchService.ts
+++ b/packages/app/src/server/lib/search/abstractSearchService.ts
@@ -1,7 +1,7 @@
 import type MeiliSearch from "meilisearch";
 import { type Logger } from "winston";
 import { type TeamId } from "../team/team";
-import { type Index } from "meilisearch";
+import { type SearchParams, type Index } from "meilisearch";
 import { waitForTasks } from "../utils/meiliSearchUtils";
 import { isError } from "@/utils/errorUtils";
 
@@ -12,7 +12,7 @@ type TeamOwnedIdentifiable = {
 
 export abstract class AbstractSearchService<
   TDoc extends object,
-  TEntity extends TeamOwnedIdentifiable
+  TEntity extends TeamOwnedIdentifiable,
 > {
   private initialized = false;
   constructor(
@@ -61,6 +61,15 @@ export abstract class AbstractSearchService<
   protected abstract onInitialize: (teamIds: TeamId[]) => Promise<void>;
 
   public getIndexName = (teamId: TeamId) => `${this.indexBaseName}_${teamId}`;
+
+  public search = async (
+    teamId: TeamId,
+    query: string | null,
+    options: SearchParams
+  ) =>
+    this.meilisearch
+      .index<TDoc>(this.getIndexName(teamId))
+      .search(query, options);
 
   public deleteIndex = async (teamId: TeamId) => {
     this.logger.info("Deleting search index", { teamId });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.11.0
         version: 11.11.0(@emotion/react@11.11.3)(@types/react@18.2.57)(react@18.2.0)
+      '@meilisearch/instant-meilisearch':
+        specifier: ^0.17.0
+        version: 0.17.0
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
         version: 1.0.7(@prisma/client@5.10.2)(next-auth@4.24.6)
@@ -113,6 +116,9 @@ importers:
       react-icons:
         specifier: ^5.0.1
         version: 5.0.1(react@18.2.0)
+      react-instantsearch:
+        specifier: ^7.7.0
+        version: 7.7.0(algoliasearch@4.23.2)(react-dom@18.2.0)(react@18.2.0)
       search-query-parser:
         specifier: ^1.6.0
         version: 1.6.0
@@ -338,6 +344,116 @@ packages:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /@algolia/cache-browser-local-storage@4.23.2:
+    resolution: {integrity: sha512-PvRQdCmtiU22dw9ZcTJkrVKgNBVAxKgD0/cfiqyxhA5+PHzA2WDt6jOmZ9QASkeM2BpyzClJb/Wr1yt2/t78Kw==}
+    dependencies:
+      '@algolia/cache-common': 4.23.2
+    dev: false
+
+  /@algolia/cache-common@4.23.2:
+    resolution: {integrity: sha512-OUK/6mqr6CQWxzl/QY0/mwhlGvS6fMtvEPyn/7AHUx96NjqDA4X4+Ju7aXFQKh+m3jW9VPB0B9xvEQgyAnRPNw==}
+    dev: false
+
+  /@algolia/cache-in-memory@4.23.2:
+    resolution: {integrity: sha512-rfbi/SnhEa3MmlqQvgYz/9NNJ156NkU6xFxjbxBtLWnHbpj+qnlMoKd+amoiacHRITpajg6zYbLM9dnaD3Bczw==}
+    dependencies:
+      '@algolia/cache-common': 4.23.2
+    dev: false
+
+  /@algolia/client-account@4.23.2:
+    resolution: {integrity: sha512-VbrOCLIN/5I7iIdskSoSw3uOUPF516k4SjDD4Qz3BFwa3of7D9A0lzBMAvQEJJEPHWdVraBJlGgdJq/ttmquJQ==}
+    dependencies:
+      '@algolia/client-common': 4.23.2
+      '@algolia/client-search': 4.23.2
+      '@algolia/transporter': 4.23.2
+    dev: false
+
+  /@algolia/client-analytics@4.23.2:
+    resolution: {integrity: sha512-lLj7irsAztGhMoEx/SwKd1cwLY6Daf1Q5f2AOsZacpppSvuFvuBrmkzT7pap1OD/OePjLKxicJS8wNA0+zKtuw==}
+    dependencies:
+      '@algolia/client-common': 4.23.2
+      '@algolia/client-search': 4.23.2
+      '@algolia/requester-common': 4.23.2
+      '@algolia/transporter': 4.23.2
+    dev: false
+
+  /@algolia/client-common@4.23.2:
+    resolution: {integrity: sha512-Q2K1FRJBern8kIfZ0EqPvUr3V29ICxCm/q42zInV+VJRjldAD9oTsMGwqUQ26GFMdFYmqkEfCbY4VGAiQhh22g==}
+    dependencies:
+      '@algolia/requester-common': 4.23.2
+      '@algolia/transporter': 4.23.2
+    dev: false
+
+  /@algolia/client-personalization@4.23.2:
+    resolution: {integrity: sha512-vwPsgnCGhUcHhhQG5IM27z8q7dWrN9itjdvgA6uKf2e9r7vB+WXt4OocK0CeoYQt3OGEAExryzsB8DWqdMK5wg==}
+    dependencies:
+      '@algolia/client-common': 4.23.2
+      '@algolia/requester-common': 4.23.2
+      '@algolia/transporter': 4.23.2
+    dev: false
+
+  /@algolia/client-search@4.23.2:
+    resolution: {integrity: sha512-CxSB29OVGSE7l/iyoHvamMonzq7Ev8lnk/OkzleODZ1iBcCs3JC/XgTIKzN/4RSTrJ9QybsnlrN/bYCGufo7qw==}
+    dependencies:
+      '@algolia/client-common': 4.23.2
+      '@algolia/requester-common': 4.23.2
+      '@algolia/transporter': 4.23.2
+    dev: false
+
+  /@algolia/events@4.0.1:
+    resolution: {integrity: sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ==}
+    dev: false
+
+  /@algolia/logger-common@4.23.2:
+    resolution: {integrity: sha512-jGM49Q7626cXZ7qRAWXn0jDlzvoA1FvN4rKTi1g0hxKsTTSReyYk0i1ADWjChDPl3Q+nSDhJuosM2bBUAay7xw==}
+    dev: false
+
+  /@algolia/logger-console@4.23.2:
+    resolution: {integrity: sha512-oo+lnxxEmlhTBTFZ3fGz1O8PJ+G+8FiAoMY2Qo3Q4w23xocQev6KqDTA1JQAGPDxAewNA2VBwWOsVXeXFjrI/Q==}
+    dependencies:
+      '@algolia/logger-common': 4.23.2
+    dev: false
+
+  /@algolia/recommend@4.23.2:
+    resolution: {integrity: sha512-Q75CjnzRCDzgIlgWfPnkLtrfF4t82JCirhalXkSSwe/c1GH5pWh4xUyDOR3KTMo+YxxX3zTlrL/FjHmUJEWEcg==}
+    dependencies:
+      '@algolia/cache-browser-local-storage': 4.23.2
+      '@algolia/cache-common': 4.23.2
+      '@algolia/cache-in-memory': 4.23.2
+      '@algolia/client-common': 4.23.2
+      '@algolia/client-search': 4.23.2
+      '@algolia/logger-common': 4.23.2
+      '@algolia/logger-console': 4.23.2
+      '@algolia/requester-browser-xhr': 4.23.2
+      '@algolia/requester-common': 4.23.2
+      '@algolia/requester-node-http': 4.23.2
+      '@algolia/transporter': 4.23.2
+    dev: false
+
+  /@algolia/requester-browser-xhr@4.23.2:
+    resolution: {integrity: sha512-TO9wLlp8+rvW9LnIfyHsu8mNAMYrqNdQ0oLF6eTWFxXfxG3k8F/Bh7nFYGk2rFAYty4Fw4XUtrv/YjeNDtM5og==}
+    dependencies:
+      '@algolia/requester-common': 4.23.2
+    dev: false
+
+  /@algolia/requester-common@4.23.2:
+    resolution: {integrity: sha512-3EfpBS0Hri0lGDB5H/BocLt7Vkop0bTTLVUBB844HH6tVycwShmsV6bDR7yXbQvFP1uNpgePRD3cdBCjeHmk6Q==}
+    dev: false
+
+  /@algolia/requester-node-http@4.23.2:
+    resolution: {integrity: sha512-SVzgkZM/malo+2SB0NWDXpnT7nO5IZwuDTaaH6SjLeOHcya1o56LSWXk+3F3rNLz2GVH+I/rpYKiqmHhSOjerw==}
+    dependencies:
+      '@algolia/requester-common': 4.23.2
+    dev: false
+
+  /@algolia/transporter@4.23.2:
+    resolution: {integrity: sha512-GY3aGKBy+8AK4vZh8sfkatDciDVKad5rTY2S10Aefyjh7e7UGBP4zigf42qVXwU8VOPwi7l/L7OACGMOFcjB0Q==}
+    dependencies:
+      '@algolia/cache-common': 4.23.2
+      '@algolia/logger-common': 4.23.2
+      '@algolia/requester-common': 4.23.2
+    dev: false
 
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -2941,6 +3057,14 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@meilisearch/instant-meilisearch@0.17.0:
+    resolution: {integrity: sha512-6SDDivDWsmYjX33m2fAUCcBvatjutBbvqV8Eg+CEllz0l6piAiDK/WlukVpYrSmhYN2YGQsJSm62WbMGciPhUg==}
+    dependencies:
+      meilisearch: 0.38.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /@napi-rs/simple-git-android-arm-eabi@0.1.16:
     resolution: {integrity: sha512-dbrCL0Pl5KZG7x7tXdtVsA5CO6At5ohDX3myf5xIYn9kN4jDFxsocl8bNt6Vb/hZQoJd8fI+k5VlJt+rFhbdVw==}
     engines: {node: '>= 10'}
@@ -3902,6 +4026,10 @@ packages:
     dependencies:
       '@types/ms': 0.7.34
 
+  /@types/dom-speech-recognition@0.0.1:
+    resolution: {integrity: sha512-udCxb8DvjcDKfk1WTBzDsxFbLgYxmQGKrE/ricoMqHRNjSlSUCcamVTA5lIQqzY10mY5qCY0QDwBfFEwhfoDPw==}
+    dev: false
+
   /@types/eslint@8.56.2:
     resolution: {integrity: sha512-uQDwm1wFHmbBbCZCqAlq6Do9LYwByNZHWzXppSnay9SuwJ+VRbjkbLABer54kcPnMSlG6Fdiy2yaFXm/z9Z5gw==}
     dependencies:
@@ -3917,6 +4045,10 @@ packages:
   /@types/estree@1.0.3:
     resolution: {integrity: sha512-CS2rOaoQ/eAgAfcTfq6amKG7bsN+EMcgGY4FAFQdvSj2y1ixvOZTUA9mOtCai7E1SYu283XNw7urKK30nP3wkQ==}
 
+  /@types/google.maps@3.55.5:
+    resolution: {integrity: sha512-U1QwCo1GeeLm0YI/GoHvfd1VfwgnoUSBcKCMXXFAM+2izSSuqqwZUJ9XNO6NxZxmYKjBNI+NF5eGF6uUSb1aSg==}
+    dev: false
+
   /@types/hast@2.3.10:
     resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
     dependencies:
@@ -3927,6 +4059,10 @@ packages:
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
     dependencies:
       '@types/unist': 3.0.2
+
+  /@types/hogan.js@3.0.5:
+    resolution: {integrity: sha512-/uRaY3HGPWyLqOyhgvW9Aa43BNnLZrNeQxl2p8wqId4UHMfPKolSB+U7BlZyO1ng7MkLnyEAItsBzCG0SDhqrA==}
+    dev: false
 
   /@types/html-minifier-terser@7.0.2:
     resolution: {integrity: sha512-mm2HqV22l8lFQh4r2oSsOEVea+m0qqxEmwpc9kC1p/XzmjLWrReR9D/GRs8Pex2NX/imyEH9c5IU/7tMBQCHOA==}
@@ -4029,6 +4165,10 @@ packages:
     dependencies:
       '@types/node': 20.11.19
     dev: true
+
+  /@types/qs@6.9.14:
+    resolution: {integrity: sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA==}
+    dev: false
 
   /@types/react-datepicker@6.0.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-oAavACLXz+Vm6kO1XZe1/LQJClOO32UUv4xva9G16KQJ2hNROtXyeGzmRg6mktHrQ+YGLnnNlN6S/XykQE2HMA==}
@@ -4502,7 +4642,6 @@ packages:
 
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
-    dev: true
 
   /acorn-jsx@5.3.2(acorn@8.10.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -4566,6 +4705,35 @@ packages:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
     dev: true
+
+  /algoliasearch-helper@3.16.3(algoliasearch@4.23.2):
+    resolution: {integrity: sha512-1OuJT6sONAa9PxcOmWo5WCAT3jQSpCR9/m5Azujja7nhUQwAUDvaaAYrcmUySsrvHh74usZHbE3jFfGnWtZj8w==}
+    peerDependencies:
+      algoliasearch: '>= 3.1 < 6'
+    dependencies:
+      '@algolia/events': 4.0.1
+      algoliasearch: 4.23.2
+    dev: false
+
+  /algoliasearch@4.23.2:
+    resolution: {integrity: sha512-8aCl055IsokLuPU8BzLjwzXjb7ty9TPcUFFOk0pYOwsE5DMVhE3kwCMFtsCFKcnoPZK7oObm+H5mbnSO/9ioxQ==}
+    dependencies:
+      '@algolia/cache-browser-local-storage': 4.23.2
+      '@algolia/cache-common': 4.23.2
+      '@algolia/cache-in-memory': 4.23.2
+      '@algolia/client-account': 4.23.2
+      '@algolia/client-analytics': 4.23.2
+      '@algolia/client-common': 4.23.2
+      '@algolia/client-personalization': 4.23.2
+      '@algolia/client-search': 4.23.2
+      '@algolia/logger-common': 4.23.2
+      '@algolia/logger-console': 4.23.2
+      '@algolia/recommend': 4.23.2
+      '@algolia/requester-browser-xhr': 4.23.2
+      '@algolia/requester-common': 4.23.2
+      '@algolia/requester-node-http': 4.23.2
+      '@algolia/transporter': 4.23.2
+    dev: false
 
   /ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -7751,6 +7919,14 @@ packages:
       bulk-replace: 0.0.1
     dev: false
 
+  /hogan.js@3.0.2:
+    resolution: {integrity: sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg==}
+    hasBin: true
+    dependencies:
+      mkdirp: 0.3.0
+      nopt: 1.0.10
+    dev: false
+
   /hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
@@ -7770,6 +7946,10 @@ packages:
     dependencies:
       lru-cache: 7.18.3
     dev: true
+
+  /htm@3.1.1:
+    resolution: {integrity: sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==}
+    dev: false
 
   /html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
@@ -7926,6 +8106,32 @@ packages:
   /inline-style-parser@0.2.2:
     resolution: {integrity: sha512-EcKzdTHVe8wFVOGEYXiW9WmJXPjqi1T+234YpJr98RiFYKHV3cdy1+3mkTE+KHTHxFFLH51SfaGOoUdW+v7ViQ==}
     dev: true
+
+  /instantsearch-ui-components@0.4.0:
+    resolution: {integrity: sha512-Isa9Ankm89e9PUXsUto6TxYzcQpXKlWZMsKLXc//dO4i9q5JS8s0Es+c+U65jRLK2j1DiVlNx/Z6HshRIZwA8w==}
+    dependencies:
+      '@babel/runtime': 7.24.0
+    dev: false
+
+  /instantsearch.js@4.66.0(algoliasearch@4.23.2):
+    resolution: {integrity: sha512-85HVTVBfO0QUBPfbCx2wPE9wEsnWQqWl8IHEOni4567IhH//CwbWv8PwHhT7rBrxSCHsxrgnMTe5dFMz7yc+/A==}
+    peerDependencies:
+      algoliasearch: '>= 3.1 < 6'
+    dependencies:
+      '@algolia/events': 4.0.1
+      '@types/dom-speech-recognition': 0.0.1
+      '@types/google.maps': 3.55.5
+      '@types/hogan.js': 3.0.5
+      '@types/qs': 6.9.14
+      algoliasearch: 4.23.2
+      algoliasearch-helper: 3.16.3(algoliasearch@4.23.2)
+      hogan.js: 3.0.2
+      htm: 3.1.1
+      instantsearch-ui-components: 0.4.0
+      preact: 10.18.1
+      qs: 6.9.7
+      search-insights: 2.13.0
+    dev: false
 
   /internal-slot@1.0.6:
     resolution: {integrity: sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==}
@@ -9210,6 +9416,14 @@ packages:
       - encoding
     dev: false
 
+  /meilisearch@0.38.0:
+    resolution: {integrity: sha512-bHaq8nYxSKw9/Qslq1Zes5g9tHgFkxy/I9o8942wv2PqlNOT0CzptIkh/x98N52GikoSZOXSQkgt6oMjtf5uZw==}
+    dependencies:
+      cross-fetch: 3.1.8
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -10041,6 +10255,11 @@ packages:
     requiresBuild: true
     optional: true
 
+  /mkdirp@0.3.0:
+    resolution: {integrity: sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==}
+    deprecated: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
+    dev: false
+
   /mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -10346,6 +10565,13 @@ packages:
 
   /non-layered-tidy-tree-layout@2.0.2:
     resolution: {integrity: sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==}
+    dev: false
+
+  /nopt@1.0.10:
+    resolution: {integrity: sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==}
+    hasBin: true
+    dependencies:
+      abbrev: 1.1.1
     dev: false
 
   /nopt@6.0.0:
@@ -11425,6 +11651,11 @@ packages:
       yargs: 15.4.1
     dev: false
 
+  /qs@6.9.7:
+    resolution: {integrity: sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==}
+    engines: {node: '>=0.6'}
+    dev: false
+
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -11533,6 +11764,36 @@ packages:
       react: '*'
     dependencies:
       react: 18.2.0
+    dev: false
+
+  /react-instantsearch-core@7.7.0(algoliasearch@4.23.2)(react@18.2.0):
+    resolution: {integrity: sha512-omUwh5JoYBOn/aa7iNtyD7t3FkJqcyscWdKaJ6VStsdAt1biDZQPpYkTG5xyZiSQ2mht99GqMm1OY1VM+zDumg==}
+    peerDependencies:
+      algoliasearch: '>= 3.1 < 5'
+      react: '>= 16.8.0 < 19'
+    dependencies:
+      '@babel/runtime': 7.24.0
+      algoliasearch: 4.23.2
+      algoliasearch-helper: 3.16.3(algoliasearch@4.23.2)
+      instantsearch.js: 4.66.0(algoliasearch@4.23.2)
+      react: 18.2.0
+      use-sync-external-store: 1.2.0(react@18.2.0)
+    dev: false
+
+  /react-instantsearch@7.7.0(algoliasearch@4.23.2)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-WDHPkmCiXxaWlgeuxcT6PKxs/xr27DO40dZZGh3Psai6/1M/BT8y4M0vLJ46gZoiQID6SfbVFKpUd2yRZznO4w==}
+    peerDependencies:
+      algoliasearch: '>= 3.1 < 5'
+      react: '>= 16.8.0 < 19'
+      react-dom: '>= 16.8.0 < 19'
+    dependencies:
+      '@babel/runtime': 7.24.0
+      algoliasearch: 4.23.2
+      instantsearch-ui-components: 0.4.0
+      instantsearch.js: 4.66.0(algoliasearch@4.23.2)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-instantsearch-core: 7.7.0(algoliasearch@4.23.2)(react@18.2.0)
     dev: false
 
   /react-is@16.13.1:
@@ -12071,6 +12332,10 @@ packages:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
     dependencies:
       compute-scroll-into-view: 3.0.3
+    dev: false
+
+  /search-insights@2.13.0:
+    resolution: {integrity: sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==}
     dev: false
 
   /search-query-parser@1.6.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       '@emotion/styled':
         specifier: ^11.11.0
         version: 11.11.0(@emotion/react@11.11.3)(@types/react@18.2.57)(react@18.2.0)
-      '@meilisearch/instant-meilisearch':
-        specifier: ^0.17.0
-        version: 0.17.0
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
         version: 1.0.7(@prisma/client@5.10.2)(next-auth@4.24.6)
@@ -116,9 +113,6 @@ importers:
       react-icons:
         specifier: ^5.0.1
         version: 5.0.1(react@18.2.0)
-      react-instantsearch:
-        specifier: ^7.7.0
-        version: 7.7.0(algoliasearch@4.23.2)(react-dom@18.2.0)(react@18.2.0)
       search-query-parser:
         specifier: ^1.6.0
         version: 1.6.0
@@ -344,116 +338,6 @@ packages:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
     dev: true
-
-  /@algolia/cache-browser-local-storage@4.23.2:
-    resolution: {integrity: sha512-PvRQdCmtiU22dw9ZcTJkrVKgNBVAxKgD0/cfiqyxhA5+PHzA2WDt6jOmZ9QASkeM2BpyzClJb/Wr1yt2/t78Kw==}
-    dependencies:
-      '@algolia/cache-common': 4.23.2
-    dev: false
-
-  /@algolia/cache-common@4.23.2:
-    resolution: {integrity: sha512-OUK/6mqr6CQWxzl/QY0/mwhlGvS6fMtvEPyn/7AHUx96NjqDA4X4+Ju7aXFQKh+m3jW9VPB0B9xvEQgyAnRPNw==}
-    dev: false
-
-  /@algolia/cache-in-memory@4.23.2:
-    resolution: {integrity: sha512-rfbi/SnhEa3MmlqQvgYz/9NNJ156NkU6xFxjbxBtLWnHbpj+qnlMoKd+amoiacHRITpajg6zYbLM9dnaD3Bczw==}
-    dependencies:
-      '@algolia/cache-common': 4.23.2
-    dev: false
-
-  /@algolia/client-account@4.23.2:
-    resolution: {integrity: sha512-VbrOCLIN/5I7iIdskSoSw3uOUPF516k4SjDD4Qz3BFwa3of7D9A0lzBMAvQEJJEPHWdVraBJlGgdJq/ttmquJQ==}
-    dependencies:
-      '@algolia/client-common': 4.23.2
-      '@algolia/client-search': 4.23.2
-      '@algolia/transporter': 4.23.2
-    dev: false
-
-  /@algolia/client-analytics@4.23.2:
-    resolution: {integrity: sha512-lLj7irsAztGhMoEx/SwKd1cwLY6Daf1Q5f2AOsZacpppSvuFvuBrmkzT7pap1OD/OePjLKxicJS8wNA0+zKtuw==}
-    dependencies:
-      '@algolia/client-common': 4.23.2
-      '@algolia/client-search': 4.23.2
-      '@algolia/requester-common': 4.23.2
-      '@algolia/transporter': 4.23.2
-    dev: false
-
-  /@algolia/client-common@4.23.2:
-    resolution: {integrity: sha512-Q2K1FRJBern8kIfZ0EqPvUr3V29ICxCm/q42zInV+VJRjldAD9oTsMGwqUQ26GFMdFYmqkEfCbY4VGAiQhh22g==}
-    dependencies:
-      '@algolia/requester-common': 4.23.2
-      '@algolia/transporter': 4.23.2
-    dev: false
-
-  /@algolia/client-personalization@4.23.2:
-    resolution: {integrity: sha512-vwPsgnCGhUcHhhQG5IM27z8q7dWrN9itjdvgA6uKf2e9r7vB+WXt4OocK0CeoYQt3OGEAExryzsB8DWqdMK5wg==}
-    dependencies:
-      '@algolia/client-common': 4.23.2
-      '@algolia/requester-common': 4.23.2
-      '@algolia/transporter': 4.23.2
-    dev: false
-
-  /@algolia/client-search@4.23.2:
-    resolution: {integrity: sha512-CxSB29OVGSE7l/iyoHvamMonzq7Ev8lnk/OkzleODZ1iBcCs3JC/XgTIKzN/4RSTrJ9QybsnlrN/bYCGufo7qw==}
-    dependencies:
-      '@algolia/client-common': 4.23.2
-      '@algolia/requester-common': 4.23.2
-      '@algolia/transporter': 4.23.2
-    dev: false
-
-  /@algolia/events@4.0.1:
-    resolution: {integrity: sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ==}
-    dev: false
-
-  /@algolia/logger-common@4.23.2:
-    resolution: {integrity: sha512-jGM49Q7626cXZ7qRAWXn0jDlzvoA1FvN4rKTi1g0hxKsTTSReyYk0i1ADWjChDPl3Q+nSDhJuosM2bBUAay7xw==}
-    dev: false
-
-  /@algolia/logger-console@4.23.2:
-    resolution: {integrity: sha512-oo+lnxxEmlhTBTFZ3fGz1O8PJ+G+8FiAoMY2Qo3Q4w23xocQev6KqDTA1JQAGPDxAewNA2VBwWOsVXeXFjrI/Q==}
-    dependencies:
-      '@algolia/logger-common': 4.23.2
-    dev: false
-
-  /@algolia/recommend@4.23.2:
-    resolution: {integrity: sha512-Q75CjnzRCDzgIlgWfPnkLtrfF4t82JCirhalXkSSwe/c1GH5pWh4xUyDOR3KTMo+YxxX3zTlrL/FjHmUJEWEcg==}
-    dependencies:
-      '@algolia/cache-browser-local-storage': 4.23.2
-      '@algolia/cache-common': 4.23.2
-      '@algolia/cache-in-memory': 4.23.2
-      '@algolia/client-common': 4.23.2
-      '@algolia/client-search': 4.23.2
-      '@algolia/logger-common': 4.23.2
-      '@algolia/logger-console': 4.23.2
-      '@algolia/requester-browser-xhr': 4.23.2
-      '@algolia/requester-common': 4.23.2
-      '@algolia/requester-node-http': 4.23.2
-      '@algolia/transporter': 4.23.2
-    dev: false
-
-  /@algolia/requester-browser-xhr@4.23.2:
-    resolution: {integrity: sha512-TO9wLlp8+rvW9LnIfyHsu8mNAMYrqNdQ0oLF6eTWFxXfxG3k8F/Bh7nFYGk2rFAYty4Fw4XUtrv/YjeNDtM5og==}
-    dependencies:
-      '@algolia/requester-common': 4.23.2
-    dev: false
-
-  /@algolia/requester-common@4.23.2:
-    resolution: {integrity: sha512-3EfpBS0Hri0lGDB5H/BocLt7Vkop0bTTLVUBB844HH6tVycwShmsV6bDR7yXbQvFP1uNpgePRD3cdBCjeHmk6Q==}
-    dev: false
-
-  /@algolia/requester-node-http@4.23.2:
-    resolution: {integrity: sha512-SVzgkZM/malo+2SB0NWDXpnT7nO5IZwuDTaaH6SjLeOHcya1o56LSWXk+3F3rNLz2GVH+I/rpYKiqmHhSOjerw==}
-    dependencies:
-      '@algolia/requester-common': 4.23.2
-    dev: false
-
-  /@algolia/transporter@4.23.2:
-    resolution: {integrity: sha512-GY3aGKBy+8AK4vZh8sfkatDciDVKad5rTY2S10Aefyjh7e7UGBP4zigf42qVXwU8VOPwi7l/L7OACGMOFcjB0Q==}
-    dependencies:
-      '@algolia/cache-common': 4.23.2
-      '@algolia/logger-common': 4.23.2
-      '@algolia/requester-common': 4.23.2
-    dev: false
 
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -3057,14 +2941,6 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@meilisearch/instant-meilisearch@0.17.0:
-    resolution: {integrity: sha512-6SDDivDWsmYjX33m2fAUCcBvatjutBbvqV8Eg+CEllz0l6piAiDK/WlukVpYrSmhYN2YGQsJSm62WbMGciPhUg==}
-    dependencies:
-      meilisearch: 0.38.0
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
   /@napi-rs/simple-git-android-arm-eabi@0.1.16:
     resolution: {integrity: sha512-dbrCL0Pl5KZG7x7tXdtVsA5CO6At5ohDX3myf5xIYn9kN4jDFxsocl8bNt6Vb/hZQoJd8fI+k5VlJt+rFhbdVw==}
     engines: {node: '>= 10'}
@@ -4026,10 +3902,6 @@ packages:
     dependencies:
       '@types/ms': 0.7.34
 
-  /@types/dom-speech-recognition@0.0.1:
-    resolution: {integrity: sha512-udCxb8DvjcDKfk1WTBzDsxFbLgYxmQGKrE/ricoMqHRNjSlSUCcamVTA5lIQqzY10mY5qCY0QDwBfFEwhfoDPw==}
-    dev: false
-
   /@types/eslint@8.56.2:
     resolution: {integrity: sha512-uQDwm1wFHmbBbCZCqAlq6Do9LYwByNZHWzXppSnay9SuwJ+VRbjkbLABer54kcPnMSlG6Fdiy2yaFXm/z9Z5gw==}
     dependencies:
@@ -4045,10 +3917,6 @@ packages:
   /@types/estree@1.0.3:
     resolution: {integrity: sha512-CS2rOaoQ/eAgAfcTfq6amKG7bsN+EMcgGY4FAFQdvSj2y1ixvOZTUA9mOtCai7E1SYu283XNw7urKK30nP3wkQ==}
 
-  /@types/google.maps@3.55.5:
-    resolution: {integrity: sha512-U1QwCo1GeeLm0YI/GoHvfd1VfwgnoUSBcKCMXXFAM+2izSSuqqwZUJ9XNO6NxZxmYKjBNI+NF5eGF6uUSb1aSg==}
-    dev: false
-
   /@types/hast@2.3.10:
     resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
     dependencies:
@@ -4059,10 +3927,6 @@ packages:
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
     dependencies:
       '@types/unist': 3.0.2
-
-  /@types/hogan.js@3.0.5:
-    resolution: {integrity: sha512-/uRaY3HGPWyLqOyhgvW9Aa43BNnLZrNeQxl2p8wqId4UHMfPKolSB+U7BlZyO1ng7MkLnyEAItsBzCG0SDhqrA==}
-    dev: false
 
   /@types/html-minifier-terser@7.0.2:
     resolution: {integrity: sha512-mm2HqV22l8lFQh4r2oSsOEVea+m0qqxEmwpc9kC1p/XzmjLWrReR9D/GRs8Pex2NX/imyEH9c5IU/7tMBQCHOA==}
@@ -4165,10 +4029,6 @@ packages:
     dependencies:
       '@types/node': 20.11.19
     dev: true
-
-  /@types/qs@6.9.14:
-    resolution: {integrity: sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA==}
-    dev: false
 
   /@types/react-datepicker@6.0.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-oAavACLXz+Vm6kO1XZe1/LQJClOO32UUv4xva9G16KQJ2hNROtXyeGzmRg6mktHrQ+YGLnnNlN6S/XykQE2HMA==}
@@ -4642,6 +4502,7 @@ packages:
 
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+    dev: true
 
   /acorn-jsx@5.3.2(acorn@8.10.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -4705,35 +4566,6 @@ packages:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
     dev: true
-
-  /algoliasearch-helper@3.16.3(algoliasearch@4.23.2):
-    resolution: {integrity: sha512-1OuJT6sONAa9PxcOmWo5WCAT3jQSpCR9/m5Azujja7nhUQwAUDvaaAYrcmUySsrvHh74usZHbE3jFfGnWtZj8w==}
-    peerDependencies:
-      algoliasearch: '>= 3.1 < 6'
-    dependencies:
-      '@algolia/events': 4.0.1
-      algoliasearch: 4.23.2
-    dev: false
-
-  /algoliasearch@4.23.2:
-    resolution: {integrity: sha512-8aCl055IsokLuPU8BzLjwzXjb7ty9TPcUFFOk0pYOwsE5DMVhE3kwCMFtsCFKcnoPZK7oObm+H5mbnSO/9ioxQ==}
-    dependencies:
-      '@algolia/cache-browser-local-storage': 4.23.2
-      '@algolia/cache-common': 4.23.2
-      '@algolia/cache-in-memory': 4.23.2
-      '@algolia/client-account': 4.23.2
-      '@algolia/client-analytics': 4.23.2
-      '@algolia/client-common': 4.23.2
-      '@algolia/client-personalization': 4.23.2
-      '@algolia/client-search': 4.23.2
-      '@algolia/logger-common': 4.23.2
-      '@algolia/logger-console': 4.23.2
-      '@algolia/recommend': 4.23.2
-      '@algolia/requester-browser-xhr': 4.23.2
-      '@algolia/requester-common': 4.23.2
-      '@algolia/requester-node-http': 4.23.2
-      '@algolia/transporter': 4.23.2
-    dev: false
 
   /ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -7919,14 +7751,6 @@ packages:
       bulk-replace: 0.0.1
     dev: false
 
-  /hogan.js@3.0.2:
-    resolution: {integrity: sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg==}
-    hasBin: true
-    dependencies:
-      mkdirp: 0.3.0
-      nopt: 1.0.10
-    dev: false
-
   /hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
@@ -7946,10 +7770,6 @@ packages:
     dependencies:
       lru-cache: 7.18.3
     dev: true
-
-  /htm@3.1.1:
-    resolution: {integrity: sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==}
-    dev: false
 
   /html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
@@ -8106,32 +7926,6 @@ packages:
   /inline-style-parser@0.2.2:
     resolution: {integrity: sha512-EcKzdTHVe8wFVOGEYXiW9WmJXPjqi1T+234YpJr98RiFYKHV3cdy1+3mkTE+KHTHxFFLH51SfaGOoUdW+v7ViQ==}
     dev: true
-
-  /instantsearch-ui-components@0.4.0:
-    resolution: {integrity: sha512-Isa9Ankm89e9PUXsUto6TxYzcQpXKlWZMsKLXc//dO4i9q5JS8s0Es+c+U65jRLK2j1DiVlNx/Z6HshRIZwA8w==}
-    dependencies:
-      '@babel/runtime': 7.24.0
-    dev: false
-
-  /instantsearch.js@4.66.0(algoliasearch@4.23.2):
-    resolution: {integrity: sha512-85HVTVBfO0QUBPfbCx2wPE9wEsnWQqWl8IHEOni4567IhH//CwbWv8PwHhT7rBrxSCHsxrgnMTe5dFMz7yc+/A==}
-    peerDependencies:
-      algoliasearch: '>= 3.1 < 6'
-    dependencies:
-      '@algolia/events': 4.0.1
-      '@types/dom-speech-recognition': 0.0.1
-      '@types/google.maps': 3.55.5
-      '@types/hogan.js': 3.0.5
-      '@types/qs': 6.9.14
-      algoliasearch: 4.23.2
-      algoliasearch-helper: 3.16.3(algoliasearch@4.23.2)
-      hogan.js: 3.0.2
-      htm: 3.1.1
-      instantsearch-ui-components: 0.4.0
-      preact: 10.18.1
-      qs: 6.9.7
-      search-insights: 2.13.0
-    dev: false
 
   /internal-slot@1.0.6:
     resolution: {integrity: sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==}
@@ -9416,14 +9210,6 @@ packages:
       - encoding
     dev: false
 
-  /meilisearch@0.38.0:
-    resolution: {integrity: sha512-bHaq8nYxSKw9/Qslq1Zes5g9tHgFkxy/I9o8942wv2PqlNOT0CzptIkh/x98N52GikoSZOXSQkgt6oMjtf5uZw==}
-    dependencies:
-      cross-fetch: 3.1.8
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -10255,11 +10041,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /mkdirp@0.3.0:
-    resolution: {integrity: sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==}
-    deprecated: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
-    dev: false
-
   /mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -10565,13 +10346,6 @@ packages:
 
   /non-layered-tidy-tree-layout@2.0.2:
     resolution: {integrity: sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==}
-    dev: false
-
-  /nopt@1.0.10:
-    resolution: {integrity: sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==}
-    hasBin: true
-    dependencies:
-      abbrev: 1.1.1
     dev: false
 
   /nopt@6.0.0:
@@ -11651,11 +11425,6 @@ packages:
       yargs: 15.4.1
     dev: false
 
-  /qs@6.9.7:
-    resolution: {integrity: sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==}
-    engines: {node: '>=0.6'}
-    dev: false
-
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -11764,36 +11533,6 @@ packages:
       react: '*'
     dependencies:
       react: 18.2.0
-    dev: false
-
-  /react-instantsearch-core@7.7.0(algoliasearch@4.23.2)(react@18.2.0):
-    resolution: {integrity: sha512-omUwh5JoYBOn/aa7iNtyD7t3FkJqcyscWdKaJ6VStsdAt1biDZQPpYkTG5xyZiSQ2mht99GqMm1OY1VM+zDumg==}
-    peerDependencies:
-      algoliasearch: '>= 3.1 < 5'
-      react: '>= 16.8.0 < 19'
-    dependencies:
-      '@babel/runtime': 7.24.0
-      algoliasearch: 4.23.2
-      algoliasearch-helper: 3.16.3(algoliasearch@4.23.2)
-      instantsearch.js: 4.66.0(algoliasearch@4.23.2)
-      react: 18.2.0
-      use-sync-external-store: 1.2.0(react@18.2.0)
-    dev: false
-
-  /react-instantsearch@7.7.0(algoliasearch@4.23.2)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-WDHPkmCiXxaWlgeuxcT6PKxs/xr27DO40dZZGh3Psai6/1M/BT8y4M0vLJ46gZoiQID6SfbVFKpUd2yRZznO4w==}
-    peerDependencies:
-      algoliasearch: '>= 3.1 < 5'
-      react: '>= 16.8.0 < 19'
-      react-dom: '>= 16.8.0 < 19'
-    dependencies:
-      '@babel/runtime': 7.24.0
-      algoliasearch: 4.23.2
-      instantsearch-ui-components: 0.4.0
-      instantsearch.js: 4.66.0(algoliasearch@4.23.2)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-instantsearch-core: 7.7.0(algoliasearch@4.23.2)(react@18.2.0)
     dev: false
 
   /react-is@16.13.1:
@@ -12332,10 +12071,6 @@ packages:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
     dependencies:
       compute-scroll-into-view: 3.0.3
-    dev: false
-
-  /search-insights@2.13.0:
-    resolution: {integrity: sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==}
     dev: false
 
   /search-query-parser@1.6.0:


### PR DESCRIPTION
Closes #62 

It's not fully compatible with all field types but now allows dynamic filters for Tags, Booleans, and Strings using MeiliSearch facets. 

Along the way, I also added that the importer can now import Assets from JSON files. It was just handy to create a bunch of test data quickly.
![SCR-20240419-bpzx-2](https://github.com/KennethWussmann/panthora/assets/11491506/21c7ce81-3e8f-4919-b8f4-dd996b70cf76)
